### PR TITLE
Chart display options

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,92 +1,135 @@
 const vm = new Vue({
-    el: '#app',
-    data: {
-        results: [],
-        chartsdata: []
+  el: '#app',
+  data: {
+    results: [],
+    chartsdata: [],
+    displaydays: 7,
+  },
+  methods: {
+    newDate: function (d) {
+      return moment().add(d, 'd')
     },
-    methods: {
-        newDate: function (d) {
-            return moment().add(d, 'd');
-        }
-    },
-    mounted() {
-        axios.get("https://api.covid19india.org/data.json")
-            .then(response => {
-                this.results = response.data.statewise
-                this.chartsdata = response.data.cases_time_series.reverse()
-                let config = {
-                    type: 'line',
-                    data: {
-                        labels: [
-                            moment().subtract(6, 'days').format('DD MMMM'),
-                            moment().subtract(5, 'days').format('DD MMMM'),
-                            moment().subtract(4, 'days').format('DD MMMM'),
-                            moment().subtract(3, 'days').format('DD MMMM'),
-                            moment().subtract(2, 'days').format('DD MMMM'),
-                            moment().subtract(1, 'days').format('DD MMMM')],
-                        datasets: [{
-                            label: 'New cases',
-                            backgroundColor: '#E64A35',
-                            borderColor: '#E64A35',
-                            data: [
-                                this.chartsdata[5].dailyconfirmed,
-                                this.chartsdata[4].dailyconfirmed,
-                                this.chartsdata[3].dailyconfirmed,
-                                this.chartsdata[2].dailyconfirmed,
-                                this.chartsdata[1].dailyconfirmed,
-                                this.chartsdata[0].dailyconfirmed
-                            ],
-                            fill: false,
-                        }, {
-                            label: 'New recoveries',
-                            fill: false,
-                            backgroundColor: 'green',
-                            borderColor: 'green',
-                            data: [
-                                this.chartsdata[5].dailyrecovered,
-                                this.chartsdata[4].dailyrecovered,
-                                this.chartsdata[3].dailyrecovered,
-                                this.chartsdata[2].dailyrecovered,
-                                this.chartsdata[1].dailyrecovered,
-                                this.chartsdata[0].dailyrecovered
-                            ],
-                        }]
-                    },
-                    options: {
-                        responsive: true,
-                        title: {
-                            display: true,
-                            text: 'Daily changes'
-                        },
-                        tooltips: {
-                            mode: 'index',
-                            intersect: false,
-                        },
-                        hover: {
-                            mode: 'nearest',
-                            intersect: true
-                        },
-                        scales: {
-                            xAxes: [{
-                                display: true,
-                                scaleLabel: {
-                                    display: true,
-                                    labelString: 'Time'
-                                },
-                            }],
-                            yAxes: [{
-                                display: true,
-                                scaleLabel: {
-                                    display: true,
-                                    labelString: 'Cases'
-                                }
-                            }]
-                        }
-                    }
-                };
+    updateDisplay: function (days) {
+      this.displaydays = days
 
-                let ctx = document.getElementById('canvas').getContext('2d');
-                window.myLine = new Chart(ctx, config);
-            })
-    }
+      axios.get('https://api.covid19india.org/data.json').then((response) => {
+        this.results = response.data.statewise
+        this.chartsdata = response.data.cases_time_series.reverse()
+
+        const startDate = moment()
+          .subtract(this.displaydays, 'days')
+          .format('DD MMMM')
+
+        const chartDisplay = this.chartsdata
+          .filter((d, i) => moment(d.date).isSameOrAfter(startDate))
+          .sort((a, b) => moment(a.date) - moment(b.date))
+
+        const dailyConfirmed = chartDisplay.map((d) => d.dailyconfirmed)
+        const dailyRecovered = chartDisplay.map((d) => d.dailyrecovered)
+
+        const labels = chartDisplay.map((d) => d.date)
+
+        window.myLine.data.labels = labels
+
+        window.myLine.data.datasets = [
+          {
+            label: 'New cases',
+            backgroundColor: '#E64A35',
+            borderColor: '#E64A35',
+            data: dailyConfirmed,
+            fill: false,
+          },
+          {
+            label: 'New recoveries',
+            fill: false,
+            backgroundColor: 'green',
+            borderColor: 'green',
+            data: dailyRecovered,
+          },
+        ]
+
+        window.myLine.update()
+      })
+    },
+  },
+  mounted() {
+    axios.get('https://api.covid19india.org/data.json').then((response) => {
+      this.results = response.data.statewise
+      this.chartsdata = response.data.cases_time_series.reverse()
+
+      const startDate = moment()
+        .subtract(this.displaydays, 'days')
+        .format('DD MMMM')
+
+      const chartDisplay = this.chartsdata
+        .filter((d, i) => moment(d.date).isSameOrAfter(startDate))
+        .sort((a, b) => moment(a.date) - moment(b.date))
+
+      const dailyConfirmed = chartDisplay.map((d) => d.dailyconfirmed)
+      const dailyRecovered = chartDisplay.map((d) => d.dailyrecovered)
+
+      const labels = chartDisplay.map((d) => d.date)
+
+      let config = {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              label: 'New cases',
+              backgroundColor: '#E64A35',
+              borderColor: '#E64A35',
+              data: dailyConfirmed,
+              fill: false,
+            },
+            {
+              label: 'New recoveries',
+              fill: false,
+              backgroundColor: 'green',
+              borderColor: 'green',
+              data: dailyRecovered,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          title: {
+            display: true,
+            text: 'Daily changes',
+          },
+          tooltips: {
+            mode: 'index',
+            intersect: false,
+          },
+          hover: {
+            mode: 'nearest',
+            intersect: true,
+          },
+          scales: {
+            xAxes: [
+              {
+                display: true,
+                scaleLabel: {
+                  display: true,
+                  labelString: 'Time',
+                },
+              },
+            ],
+            yAxes: [
+              {
+                display: true,
+                scaleLabel: {
+                  display: true,
+                  labelString: 'Cases',
+                },
+              },
+            ],
+          },
+        },
+      }
+
+      let ctx = document.getElementById('canvas').getContext('2d')
+      window.myLine = new Chart(ctx, config)
+    })
+  },
 })

--- a/index.html
+++ b/index.html
@@ -77,10 +77,30 @@
         <div class="col-sm-12 col-lg-5">
           <canvas id="canvas" width="400" height="300"></canvas>
           <div class="display-options">
-            <button v-on:click="updateDisplay(7)">7 Days</button>
-            <button v-on:click="updateDisplay(15)">15 Days</button>
-            <button v-on:click="updateDisplay(30)">30 Days</button>
-            <button v-on:click="updateDisplay(60)">60 Days</button>
+            <button
+              v-bind:class="{ 'active-display': displaydays === 7 }"
+              v-on:click="updateDisplay(7)"
+            >
+              7 Days
+            </button>
+            <button
+              v-bind:class="{ 'active-display': displaydays === 15 }"
+              v-on:click="updateDisplay(15)"
+            >
+              15 Days
+            </button>
+            <button
+              v-bind:class="{ 'active-display': displaydays === 30 }"
+              v-on:click="updateDisplay(30)"
+            >
+              30 Days
+            </button>
+            <button
+              v-bind:class="{ 'active-display': displaydays === 60 }"
+              v-on:click="updateDisplay(60)"
+            >
+              60 Days
+            </button>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -1,81 +1,90 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-    <meta charset="utf-8">
-    <meta name="author" content="Rahul Gurung">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="author" content="Rahul Gurung" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Covid19Web | Get LIVE Corona stats</title>
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
-        integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <link href="https://fonts.googleapis.com/css2?family=Righteous&family=Roboto&display=swap" rel="stylesheet">
+    <link
+      rel="stylesheet"
+      href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
+      integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Righteous&family=Roboto&display=swap"
+      rel="stylesheet"
+    />
     <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
-    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="style.css" />
     <link rel="shortcut icon" type="image/png" href="./assets/favicon.ico" />
-</head>
+  </head>
 
-<body>
+  <body>
     <div class="container covid-container">
-        <div class="row">
-            <div class="col-sm-12 col-lg-6">
-                <h3 class="text-left covid-title">Covid19Web</h3>
-            </div>
+      <div class="row">
+        <div class="col-sm-12 col-lg-6">
+          <h3 class="text-left covid-title">Covid19Web</h3>
         </div>
+      </div>
     </div>
     <div class="container covid-container" id="app" v-cloak>
-        <div class="row">
-            <div class="col-sm-12 col-lg-7">
-                <table class="table table-sm">
-                    <thead>
-                        <tr>
-                            <th>State</th>
-                            <th>Confirmed</th>
-                            <th>Deaths</th>
-                            <th>Recovered</th>
-                        </tr>
-                    </thead>
-                    <tbody v-for="(result, index) in results">
-                        <tr v-bind:class="{'table-active' : index == 0}">
-                            <td>
-                                {{result.state}}
-                            </td>
-                            <td>
-                                {{result.confirmed}}
-                                <span v-if="result.deltaconfirmed > 0">
-                                    <span class="covid-danger">
-                                        +{{ result.deltaconfirmed }}
-                                    </span>
-                                </span>
-                            </td>
-                            <td>
-                                {{result.deaths}}
-                                <span v-if="result.deltadeaths > 0">
-                                    <span class="covid-danger">
-                                        +{{ result.deltadeaths }}
-                                    </span>
-                                </span>
-                            </td>
-                            <td>
-                                {{result.recovered}}
-                                <span v-if="result.deltarecovered > 0">
-                                    <span class="covid-safe">
-                                        +{{ result.deltarecovered }}
-                                    </span>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="col-sm-12 col-lg-5">
-                <canvas id="canvas" width="400" height="300"></canvas>
-            </div>
+      <div class="row">
+        <div class="col-sm-12 col-lg-7">
+          <table class="table table-sm">
+            <thead>
+              <tr>
+                <th>State</th>
+                <th>Confirmed</th>
+                <th>Deaths</th>
+                <th>Recovered</th>
+              </tr>
+            </thead>
+            <tbody v-for="(result, index) in results">
+              <tr v-bind:class="{'table-active' : index == 0}">
+                <td>{{result.state}}</td>
+                <td>
+                  {{result.confirmed}}
+                  <span v-if="result.deltaconfirmed > 0">
+                    <span class="covid-danger">
+                      +{{ result.deltaconfirmed }}
+                    </span>
+                  </span>
+                </td>
+                <td>
+                  {{result.deaths}}
+                  <span v-if="result.deltadeaths > 0">
+                    <span class="covid-danger">
+                      +{{ result.deltadeaths }}
+                    </span>
+                  </span>
+                </td>
+                <td>
+                  {{result.recovered}}
+                  <span v-if="result.deltarecovered > 0">
+                    <span class="covid-safe">
+                      +{{ result.deltarecovered }}
+                    </span>
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
+        <div class="col-sm-12 col-lg-5">
+          <canvas id="canvas" width="400" height="300"></canvas>
+          <div class="display-options">
+            <button v-on:click="updateDisplay(7)">7 Days</button>
+            <button v-on:click="updateDisplay(15)">15 Days</button>
+            <button v-on:click="updateDisplay(30)">30 Days</button>
+            <button v-on:click="updateDisplay(60)">60 Days</button>
+          </div>
+        </div>
+      </div>
     </div>
     <script src="app.js"></script>
-</body>
-
+  </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -45,6 +45,10 @@ body::-webkit-scrollbar {
   align-items: center;
 }
 
+.active-display {
+  filter: invert(100%);
+}
+
 a,
 li {
   font-family: 'Roboto', sans-serif;

--- a/style.css
+++ b/style.css
@@ -38,13 +38,19 @@ body::-webkit-scrollbar {
   font-size: 10px;
 }
 
+.display-options {
+  margin-top: 1.5em;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
 a,
 li {
   font-family: 'Roboto', sans-serif;
 }
 
 td {
-    
 }
 
 [v-cloak] {


### PR DESCRIPTION
RE: https://github.com/gurrrung/Covid19Web/issues/4

Adds options for displaying chart data based on the past 7 / 15 / 30 / 60 days
 - Adds buttons to trigger state update in Vue instance for `displaydays`
 - Adds method to filter data based on `displaydays` and update chart accordingly

BEFORE
![chart-display-static](https://user-images.githubusercontent.com/22434740/94994262-87507e80-0564-11eb-8bca-bb8baa648b83.png)

AFTER
![chart-display](https://user-images.githubusercontent.com/22434740/94994267-8b7c9c00-0564-11eb-83be-72556ef866df.gif)
